### PR TITLE
Allow Command-Value to be passed through to Scribe

### DIFF
--- a/src/scribe-plugin-toolbar.js
+++ b/src/scribe-plugin-toolbar.js
@@ -19,7 +19,7 @@ define(function () {
            * the command, because it might rely on selection data.
            */
           scribe.el.focus();
-          command.execute();
+          command.execute(button.dataset.commandValue);
           /**
            * Chrome has a bit of magic to re-focus the `contenteditable` when a
            * command is executed.
@@ -46,7 +46,7 @@ define(function () {
           var selection = new scribe.api.Selection();
 
           // TODO: Do we need to check for the selection?
-          if (selection.range && command.queryState()) {
+          if (selection.range && command.queryState(button.dataset.commandValue)) {
             button.classList.add('active');
           } else {
             button.classList.remove('active');

--- a/test/integration/main.spec.js
+++ b/test/integration/main.spec.js
@@ -38,9 +38,23 @@ describe('toolbar plugin', function () {
       var vendorButton = window.document.createElement('button');
       vendorButton.innerText = 'Leave vendor alone!';
 
+      // Create buttons with command value
+      var fontButtonImpact = window.document.createElement('button');
+      fontButtonImpact.setAttribute('data-command-value', 'Impact');
+      fontButtonImpact.setAttribute('data-command-name', 'fontName');
+      fontButtonImpact.classList.add('command-value');
+      fontButtonImpact.innerText = 'Set font to Impact';
+      var fontButtonArial = window.document.createElement('button');
+      fontButtonArial.setAttribute('data-command-value', 'Arial');
+      fontButtonArial.setAttribute('data-command-name', 'fontName');
+      fontButtonArial.classList.add('command-value');
+      fontButtonArial.innerText = 'Set font to Arial';
+
       // Add them to the DOM
       toolbarDiv.appendChild(defaultButton);
       toolbarDiv.appendChild(vendorButton);
+      toolbarDiv.appendChild(fontButtonArial);
+      toolbarDiv.appendChild(fontButtonImpact);
       body.appendChild(toolbarDiv);
 
       require(['../../src/scribe-plugin-toolbar'], function (toolbarPlugin) {
@@ -68,6 +82,22 @@ describe('toolbar plugin', function () {
             // We have a vendor button, it shouldn't be disabled
             expect(button.disabled).to.not.be.ok;
           }
+        });
+      });
+    });
+  });
+
+  when('clicking a button with an associated command value', function() {
+    it('should pass through the command value', function() {
+      return driver.executeScript(function() {
+        var commandValueButtons = window.document.querySelectorAll('.scribe-toolbar button.command-value');
+        Array.prototype.forEach.call(commandValueButtons, function(button) {
+          // Click the button
+          button.click();
+
+          // Verify that the command was executed with the appropriate value
+          var expectedFont = button.dataset.commandValue;
+          expect(document.queryCommandValue('fontName')).to.be(expectedFont);
         });
       });
     });


### PR DESCRIPTION
This is a very basic change, and a basic test case to illustrate the passing of command-value through to scribe.  This is useful in cases such as when a font-face, background-color, creating a link, and basically any editing option which is not a simple boolean.