### PR TITLE
Add support for disabled tags for commands as data attribute

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,10 @@
+{
+  "browser": true,
+  "eqeqeq": true, // ===
+  "laxbreak": true, // Tolerate unsafe line breaks e.g. `return [\n] x` without semicolons.
+  "node": true,
+  "predef": ["define"],
+  "quotmark": "single",
+  "undef": true, // Prohibits the use of explicitly undeclared variables
+  "unused": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,28 +2,24 @@ language: node_js
 node_js:
   - 0.10
 
+sudo: false
+
 addons:
   sauce_connect:
     username: scribe-ci
     access_key: 4be9eeed-61de-4948-b18d-f7f655e9e4b0
 env:
   matrix:
-    - BROWSER_NAME='firefox' BROWSER_VERSION='21' PLATFORM='Windows XP'
-    - BROWSER_NAME='firefox' BROWSER_VERSION='22' PLATFORM='Windows XP'
-    - BROWSER_NAME='firefox' BROWSER_VERSION='23' PLATFORM='Windows XP'
-    - BROWSER_NAME='firefox' BROWSER_VERSION='24' PLATFORM='Windows XP'
-    - BROWSER_NAME='firefox' BROWSER_VERSION='25' PLATFORM='Windows XP'
-    - BROWSER_NAME='firefox' BROWSER_VERSION='26' PLATFORM='Windows XP'
-    - BROWSER_NAME='firefox' BROWSER_VERSION='27' PLATFORM='Windows XP'
-    - BROWSER_NAME='firefox' BROWSER_VERSION='28' PLATFORM='Windows XP'
-    - BROWSER_NAME='chrome' BROWSER_VERSION='27' PLATFORM='Windows XP'
-    - BROWSER_NAME='chrome' BROWSER_VERSION='28' PLATFORM='Windows XP'
-    - BROWSER_NAME='chrome' BROWSER_VERSION='29' PLATFORM='Windows XP'
-    - BROWSER_NAME='chrome' BROWSER_VERSION='30' PLATFORM='Windows XP'
-    - BROWSER_NAME='chrome' BROWSER_VERSION='31' PLATFORM='Windows XP'
-    - BROWSER_NAME='chrome' BROWSER_VERSION='32' PLATFORM='Windows XP'
-    - BROWSER_NAME='chrome' BROWSER_VERSION='33' PLATFORM='Windows XP'
-    - BROWSER_NAME='chrome' BROWSER_VERSION='34' PLATFORM='Windows XP'
+  matrix:
+    - BROWSER_NAME='firefox' BROWSER_VERSION='31' PLATFORM='OSX 10.6'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='32' PLATFORM='OSX 10.6'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='33' PLATFORM='OSX 10.6'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='35' PLATFORM='OSX 10.8'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='36' PLATFORM='OSX 10.8'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='37' PLATFORM='OSX 10.8'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='38' PLATFORM='OSX 10.8'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='33' PLATFORM='Windows 7'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='38' PLATFORM='Windows 7'
 
 before_script:
   - npm install -g bower

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: node_js
+node_js:
+  - 0.10
+
+addons:
+  sauce_connect:
+    username: scribe-ci
+    access_key: 4be9eeed-61de-4948-b18d-f7f655e9e4b0
+env:
+  matrix:
+    - BROWSER_NAME='firefox' BROWSER_VERSION='21' PLATFORM='Windows XP'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='22' PLATFORM='Windows XP'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='23' PLATFORM='Windows XP'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='24' PLATFORM='Windows XP'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='25' PLATFORM='Windows XP'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='26' PLATFORM='Windows XP'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='27' PLATFORM='Windows XP'
+    - BROWSER_NAME='firefox' BROWSER_VERSION='28' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='27' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='28' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='29' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='30' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='31' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='32' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='33' PLATFORM='Windows XP'
+    - BROWSER_NAME='chrome' BROWSER_VERSION='34' PLATFORM='Windows XP'
+
+before_script:
+  - npm install -g bower
+  - bower install
+script: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.0
+
+Command values can now be passed through from the buttons. Thanks [bigdave](https://github.com/bigdave)
 
 # 0.1.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+
+# 0.1.5
+
+Toolbars shouldn't need to consist of button elements anymore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+See https://github.com/guardian/scribe/blob/master/CONTRIBUTING.md.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2014 Guardian News & Media Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
-# scribe-plugin-toolbar
+# scribe-plugin-toolbar [![Build Status](https://travis-ci.org/guardian/scribe-plugin-toolbar.svg?branch=master)](https://travis-ci.org/guardian/scribe-plugin-toolbar)
 
+## Installation
 ```
 bower install scribe-plugin-toolbar
+```
+
+Alternatively, you can [access the distribution files through GitHub releases](https://github.com/guardian/scribe-plugin-toolbar/releases).
+
+## Usage Example
+
+scribe-plugin-toolbar is an AMD module:
+
+``` js
+require(['scribe', 'scribe-plugin-toolbar'], function (Scribe, scribePluginToolbar) {
+  var scribeElement = document.querySelector('.scribe');
+  // Create an instance of Scribe
+  var scribe = new Scribe(scribeElement);
+
+  var toolbarElement = document.querySelector('.toolbar');
+  scribe.use(scribePluginToolbar(toolbarElement));
+});
 ```

--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ require(['scribe', 'scribe-plugin-toolbar'], function (Scribe, scribePluginToolb
   scribe.use(scribePluginToolbar(toolbarElement));
 });
 ```
+
+For more documentation see the [project wiki](https://github.com/guardian/scribe-plugin-toolbar/wiki)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # scribe-plugin-toolbar [![Build Status](https://travis-ci.org/guardian/scribe-plugin-toolbar.svg?branch=master)](https://travis-ci.org/guardian/scribe-plugin-toolbar)
 
+A toolbar of buttons and shortcuts for Scribe
+
 ## Installation
 ```
 bower install scribe-plugin-toolbar

--- a/bower.json
+++ b/bower.json
@@ -1,3 +1,10 @@
 {
-  "name": "scribe-plugin-toolbar"
+  "name": "scribe-plugin-toolbar",
+  "dependencies": {
+    "lodash-amd": "2.4.1"
+  },
+  "devDependencies": {
+    "requirejs": "~2.1.9",
+    "scribe": "~0.1.10"
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,5 @@
 {
   "name": "scribe-plugin-toolbar",
-  "dependencies": {
-    "lodash-amd": "2.4.1"
-  },
   "devDependencies": {
     "requirejs": "~2.1.9",
     "scribe": "~0.1.10"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,10 @@
 {
   "name": "scribe-plugin-toolbar",
+  "version": "0.1.2",
+  "main": "src/scribe-plugin-toolbar.js",
+  "dependencies": {
+    "lodash-amd": "~2.4.1"
+  },
   "devDependencies": {
     "chai": "~1.9.1",
     "http-server": "~0.6.1",
@@ -14,5 +19,9 @@
   },
   "scripts": {
     "test": "./run-tests.sh"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/guardian/scribe-plugin-toolbar.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "chai": "~1.9.1",
     "http-server": "~0.6.1",
     "mocha": "~1.18.2",
-    "plumber": "~0.3.0",
-    "plumber-all": "~0.3.0",
-    "plumber-glob": "~0.3.0",
-    "plumber-requirejs": "~0.3.0",
-    "plumber-uglifyjs": "~0.3.0",
-    "plumber-write": "~0.3.0",
-    "scribe-test-harness": "~0.0.1"
+    "plumber": "~0.4.0",
+    "plumber-all": "~0.4.0",
+    "plumber-glob": "~0.4.0",
+    "plumber-requirejs": "~0.4.0",
+    "plumber-uglifyjs": "~0.4.0",
+    "plumber-write": "~0.4.0",
+    "scribe-test-harness": "~0.0.17"
   },
   "scripts": {
     "test": "./run-tests.sh"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scribe-plugin-toolbar",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "src/scribe-plugin-toolbar.js",
   "dependencies": {
     "lodash-amd": "~2.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scribe-plugin-toolbar",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "src/scribe-plugin-toolbar.js",
   "dependencies": {
     "lodash-amd": "~2.4.1"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,18 @@
 {
   "name": "scribe-plugin-toolbar",
   "devDependencies": {
+    "chai": "~1.9.1",
+    "http-server": "~0.6.1",
+    "mocha": "~1.18.2",
     "plumber": "~0.3.0",
     "plumber-all": "~0.3.0",
     "plumber-glob": "~0.3.0",
     "plumber-requirejs": "~0.3.0",
     "plumber-uglifyjs": "~0.3.0",
-    "plumber-write": "~0.3.0"
+    "plumber-write": "~0.3.0",
+    "scribe-test-harness": "~0.0.1"
+  },
+  "scripts": {
+    "test": "./run-tests.sh"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scribe-plugin-toolbar",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "main": "src/scribe-plugin-toolbar.js",
   "dependencies": {
     "lodash-amd": "~2.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scribe-plugin-toolbar",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "src/scribe-plugin-toolbar.js",
   "dependencies": {
     "lodash-amd": "~2.4.1"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./node_modules/.bin/http-server --silent &
+node test/integration/runner

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
 
-./node_modules/.bin/http-server --silent &
+export BROWSER_NAME=${BROWSER_NAME:=chrome}
+
+export TEST_SERVER_PORT=${TEST_SERVER_PORT:=8880}
+
+./node_modules/.bin/http-server -p $TEST_SERVER_PORT --silent &
+PID=$!
 node test/integration/runner
+TEST_RUNNER_EXIT=$?
+kill $PID
+
+if [ $TEST_RUNNER_EXIT == "0" ]; then
+    exit 0
+else
+    exit 1
+fi
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,9 @@
+npm install
+bower install
+
+# Download the selenium JAR
+SELENIUM_VERSION=2.41.0
+SELENIUM_MINOR_VERSION=2.41
+mkdir -p vendor
+wget -O vendor/selenium-server-standalone-$SELENIUM_VERSION.jar \
+  https://selenium-release.storage.googleapis.com/$SELENIUM_MINOR_VERSION/selenium-server-standalone-$SELENIUM_VERSION.jar

--- a/src/scribe-plugin-toolbar.js
+++ b/src/scribe-plugin-toolbar.js
@@ -1,3 +1,17 @@
+/**
+ * Plugin to attach functionality to the Scribe editor toolbar.
+ * Example markup of toolbar:
+ *
+ * <button data-command-name="bold"<strong>B</strong></button>
+ * <button data-command-name="italic"><em>I</em></button>
+ * <button data-command-name="code" data-disabled-tags="ol,ul,table">Code</button>
+ *
+ * Supported data attributes:
+ *
+ * data-command-name: Command name.
+ * data-command-value: Command value.
+ * data-disabled-tags: Tags for which the command is disabled.
+ */
 define(function () {
 
   'use strict';
@@ -27,37 +41,45 @@ define(function () {
            */
         });
 
-        // Keep the state of toolbar buttons in sync with the current selection.
-        // Unfortunately, there is no `selectionchange` event.
-        scribe.el.addEventListener('keyup', updateUi);
-        scribe.el.addEventListener('mouseup', updateUi);
-
-        scribe.el.addEventListener('focus', updateUi);
-        scribe.el.addEventListener('blur', updateUi);
-
-        // We also want to update the UI whenever the content changes. This
-        // could be when one of the toolbar buttons is actioned.
-        scribe.on('content-changed', updateUi);
-
-        function updateUi() {
+        function update() {
           // Look for a predefined command.
           var command = scribe.getCommand(button.dataset.commandName);
-
           var selection = new scribe.api.Selection();
+          var disabledTags = button.dataset.disabledTags ? button.dataset.disabledTags.split(',') : [];
+
+          var shouldDisable = selection.getContaining(function(node) {
+            var nodeName = node.nodeName.toLowerCase();
+            return (disabledTags.indexOf(nodeName) !== -1);
+          });
+
+          // see https://github.com/guardian/scribe/issues/208
+          var isListCommand = ['insertUnorderedList', 'insertOrderedList'].indexOf(command) !== -1;
 
           // TODO: Do we need to check for the selection?
-          if (selection.range && command.queryState(button.dataset.commandValue)) {
+          if (selection.range && !isListCommand && command.queryState(button.dataset.commandValue)) {
             button.classList.add('active');
           } else {
             button.classList.remove('active');
           }
 
-          if (selection.range && command.queryEnabled()) {
+          if (selection.range && command.queryEnabled() && !shouldDisable) {
             button.removeAttribute('disabled');
           } else {
             button.setAttribute('disabled', 'disabled');
           }
         }
+
+        // Keep the state of toolbar buttons in sync with the current selection.
+        // Unfortunately, there is no `selectionchange` event.
+        scribe.el.addEventListener('keyup', update);
+        scribe.el.addEventListener('mouseup', update);
+
+        scribe.el.addEventListener('focus', update);
+        scribe.el.addEventListener('blur', update);
+
+        // We also want to update the UI whenever the content changes. This
+        // could be when one of the toolbar buttons is actioned.
+        scribe.on('content-changed', update);
       });
     };
   };

--- a/src/scribe-plugin-toolbar.js
+++ b/src/scribe-plugin-toolbar.js
@@ -7,10 +7,10 @@ define(function () {
       var buttons = toolbarNode.querySelectorAll('button[data-command-name]');
 
       Array.prototype.forEach.call(buttons, function (button) {
-        // Look for a predefined command, otherwise define one now.
-        var command = scribe.getCommand(button.dataset.commandName);
-
         button.addEventListener('click', function () {
+          // Look for a predefined command, otherwise define one now.
+          var command = scribe.getCommand(button.dataset.commandName);
+
           /**
            * Focus will have been taken away from the Scribe instance when
            * clicking on a button (Chrome will return the focus automatically

--- a/src/scribe-plugin-toolbar.js
+++ b/src/scribe-plugin-toolbar.js
@@ -52,11 +52,8 @@ define(function () {
             return (disabledTags.indexOf(nodeName) !== -1);
           });
 
-          // see https://github.com/guardian/scribe/issues/208
-          var isListCommand = ['insertUnorderedList', 'insertOrderedList'].indexOf(command) !== -1;
-
           // TODO: Do we need to check for the selection?
-          if (selection.range && !isListCommand && command.queryState(button.dataset.commandValue)) {
+          if (selection.range && command.queryState(button.dataset.commandValue)) {
             button.classList.add('active');
           } else {
             button.classList.remove('active');

--- a/src/scribe-plugin-toolbar.js
+++ b/src/scribe-plugin-toolbar.js
@@ -45,14 +45,15 @@ define(function () {
 
           var selection = new scribe.api.Selection();
 
+          // TODO: Do we need to check for the selection?
+          if (selection.range && command.queryState()) {
+            button.classList.add('active');
+          } else {
+            button.classList.remove('active');
+          }
+
           if (selection.range && command.queryEnabled()) {
             button.removeAttribute('disabled');
-
-            if (command.queryState()) {
-              button.classList.add('active');
-            } else {
-              button.classList.remove('active');
-            }
           } else {
             button.setAttribute('disabled', 'disabled');
           }

--- a/src/scribe-plugin-toolbar.js
+++ b/src/scribe-plugin-toolbar.js
@@ -19,7 +19,7 @@ define(function () {
            * the command, because it might rely on selection data.
            */
           scribe.el.focus();
-          command.execute();
+          command.execute(button.dataset.commandValue);
           /**
            * Chrome has a bit of magic to re-focus the `contenteditable` when a
            * command is executed.
@@ -46,7 +46,7 @@ define(function () {
           var selection = new scribe.api.Selection();
 
           // TODO: Do we need to check for the selection?
-          if (selection.range && command.queryState()) {
+          if (selection.range && command.queryState(button.dataset.commandValue)) {
             button.classList.add('active');
           } else {
             button.classList.remove('active');

--- a/src/scribe-plugin-toolbar.js
+++ b/src/scribe-plugin-toolbar.js
@@ -4,7 +4,7 @@ define(function () {
 
   return function (toolbarNode) {
     return function (scribe) {
-      var buttons = toolbarNode.querySelectorAll('button[data-command-name]');
+      var buttons = toolbarNode.querySelectorAll('[data-command-name]');
 
       Array.prototype.forEach.call(buttons, function (button) {
         button.addEventListener('click', function () {

--- a/src/scribe-plugin-toolbar.js
+++ b/src/scribe-plugin-toolbar.js
@@ -40,6 +40,9 @@ define(function () {
         scribe.on('content-changed', updateUi);
 
         function updateUi() {
+          // Look for a predefined command.
+          var command = scribe.getCommand(button.dataset.commandName);
+
           var selection = new scribe.api.Selection();
 
           if (selection.range && command.queryEnabled()) {

--- a/src/scribe-plugin-toolbar.js
+++ b/src/scribe-plugin-toolbar.js
@@ -8,7 +8,7 @@ define(function () {
 
       Array.prototype.forEach.call(buttons, function (button) {
         button.addEventListener('click', function () {
-          // Look for a predefined command, otherwise define one now.
+          // Look for a predefined command.
           var command = scribe.getCommand(button.dataset.commandName);
 
           /**

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,16 @@
+{
+  "extends": "../.jshintrc",
+  "browser": false,
+  // Allow standalone expressions (needed for expectations such as `expect(foo).to.be.undefined`)
+  // See: https://github.com/chaijs/chai/issues/41
+  "expr": true,
+  "predef": [
+    "after",
+    "afterEach",
+    "before",
+    "beforeEach",
+    "describe",
+    "it",
+    "window"
+  ]
+}

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <div class="scribe"></div>
+    <script src="../../bower_components/requirejs/require.js"></script>
+    <script>
+      require.config({
+        paths: {
+          // We have to define a path to Scribe otherwise it will load the file
+          // but will not pass along the 'scribe' AMD module.
+          'scribe': '../../bower_components/scribe/scribe',
+          'lodash-modern': '../../bower_components/lodash-amd/modern'
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/test/integration/main.spec.js
+++ b/test/integration/main.spec.js
@@ -38,9 +38,23 @@ describe('toolbar plugin', function () {
       var vendorButton = window.document.createElement('button');
       vendorButton.innerText = 'Leave vendor alone!';
 
+      // Create buttons with command value
+      var fontButtonImpact = window.document.createElement('button');
+      fontButtonImpact.setAttribute('data-command-value', 'Impact');
+      fontButtonImpact.setAttribute('data-command-name', 'fontName');
+      fontButtonImpact.classList.add('command-value');
+      fontButtonImpact.innerText = 'Set font to Impact';
+      var fontButtonArial = window.document.createElement('button');
+      fontButtonArial.setAttribute('data-command-value', 'Arial');
+      fontButtonArial.setAttribute('data-command-name', 'fontName');
+      fontButtonArial.classList.add('command-value');
+      fontButtonArial.innerText = 'Set font to Arial';
+
       // Add them to the DOM
       toolbarDiv.appendChild(defaultButton);
       toolbarDiv.appendChild(vendorButton);
+      toolbarDiv.appendChild(fontButtonArial);
+      toolbarDiv.appendChild(fontButtonImpact);
       body.appendChild(toolbarDiv);
 
       require(['../../src/scribe-plugin-toolbar'], function (toolbarPlugin) {
@@ -68,6 +82,22 @@ describe('toolbar plugin', function () {
             // We have a vendor button, it shouldn't be disabled
             expect(button.disabled).to.not.be.ok;
           }
+        });
+      });
+    });
+  });
+
+  when('clicking a button with an associated command value', function() {
+    it('should pass through the command value', function() {
+      return driver.executeScript(function() {
+        var commandValueButtons = window.document.querySelectorAll('.scribe-toolbar button.command-value');
+        Array.prototype.forEach.call(commandValueButtons, function(button) {
+          // Click the button
+          button.click();
+
+          // Verify that the command was executed with the appropriate value
+          var expectedFont = button.dataset.commandValue;
+          expect(document.queryCommandValue('fontName')).to.be(expectedFont);
         });
       });
     });

--- a/test/integration/main.spec.js
+++ b/test/integration/main.spec.js
@@ -1,0 +1,75 @@
+var chai = require('chai');
+var expect = chai.expect;
+
+var helpers = require('scribe-test-harness/helpers');
+helpers.registerChai(chai);
+var when = helpers.when;
+var initializeScribe = helpers.initializeScribe.bind(null, 'scribe');
+
+// Get new referenceS each time a new instance is created
+var driver;
+before(function () {
+  driver = helpers.driver;
+});
+
+var scribeNode;
+beforeEach(function () {
+  scribeNode = helpers.scribeNode;
+});
+
+describe('toolbar plugin', function () {
+  beforeEach(function () {
+    return initializeScribe();
+  });
+
+  beforeEach(function () {
+    return driver.executeAsyncScript(function (done) {
+      var body = window.document.querySelector('body');
+      // Create toolbar
+      var toolbarDiv = window.document.createElement('div');
+      toolbarDiv.className = 'scribe-toolbarDiv';
+
+      // Create one default button
+      var defaultButton = window.document.createElement('button');
+      defaultButton.setAttribute('data-command-name', 'removeFormat');
+      defaultButton.innerText = 'Remove Format';
+
+      // Create a vendor button
+      var vendorButton = window.document.createElement('button');
+      vendorButton.innerText = 'Leave vendor alone!';
+
+      // Add them to the DOM
+      toolbarDiv.appendChild(defaultButton);
+      toolbarDiv.appendChild(vendorButton);
+      body.appendChild(toolbarDiv);
+
+      require(['../../src/scribe-plugin-toolbar'], function (toolbarPlugin) {
+        window.scribe.use(toolbarPlugin(toolbarDiv));
+        done();
+      });
+    });
+  });
+
+  when('updating the toolbar ui', function () {
+    beforeEach(function () {
+      // Click in the contenteditable to enable/disable relevant buttons
+      return scribeNode.click();
+    });
+
+    it('should not disable vendor buttons', function () {
+      return driver.executeScript(function () {
+        var vendorButtons = window.document.querySelectorAll('.scribe-toolbar button');
+        Array.prototype.forEach.call(vendorButtons, function(button) {
+          if (button.hasAttribute('data-command-name')) {
+            // We have a default button, which is disabled when no text is
+            // inserted
+            expect(button.disabled).to.be.ok;
+          } else {
+            // We have a vendor button, it shouldn't be disabled
+            expect(button.disabled).to.not.be.ok;
+          }
+        });
+      });
+    });
+  });
+});

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -1,0 +1,16 @@
+var Mocha = require('mocha');
+var createRunner = require('scribe-test-harness/create-runner');
+
+var mocha = new Mocha();
+
+/**
+ * FIXME: We have to set a ridiculous timeout (20 minutes) because Travis’
+ * concurrent builds will sometimes exceed Sauce Labs’ concurrency. We should
+ * track the following issue to add an option to Travis for limiting
+ * concurrency: https://github.com/travis-ci/travis-ci/issues/1366
+ */
+mocha.timeout(1200000);
+mocha.reporter('spec');
+mocha.addFile(__dirname + '/main.spec.js');
+
+createRunner(mocha);


### PR DESCRIPTION
This is to add support for `data-disabled-tags` to disable a command inside specific tags. For example, this will let one disable inserting images inside a table. Or, disable inserting lists inside code. 

Maybe there is a better name for the attribute =]
