### PR TITLE
Changed click to mousedown for fixing issue with chrome and flexbox.

### DIFF
--- a/src/scribe-plugin-toolbar.js
+++ b/src/scribe-plugin-toolbar.js
@@ -7,7 +7,7 @@ define(function () {
       var buttons = toolbarNode.querySelectorAll('[data-command-name]');
 
       Array.prototype.forEach.call(buttons, function (button) {
-        button.addEventListener('click', function () {
+        button.addEventListener('mousedown', function () {
           // Look for a predefined command.
           var command = scribe.getCommand(button.dataset.commandName);
 


### PR DESCRIPTION
Webkit fails in contenteditables.

What happes is, that clicking the toolbar removes focus and selection from contenteditable and cannot execute the command.

This happens when the contenteditable is part of a flexbox structure.

In http://stackoverflow.com/questions/7392959/how-do-you-avoid-losing-focus-on-a-contenteditable-element-when-a-user-clicks-ou I got inspired to simply change the event type to mousedown. 

Unsure wether or not to include preventDefault(). It seems to work just fine without it.